### PR TITLE
Mark ceres-solver 2.2 as unsupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 --
 
+## [0.2.2] 2024-02-26
+
+### Changed
+
+- Bump `ceser-solver-sys` to `0.2.2`, which requires `ceres-solver` version to be between 2.0 and 2.1, because 2.2 is known to be incompatible.
+
 ## [0.2.1] 2023-03-02
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceres-solver"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 readme = "README.md"
 description = "Safe Rust bindings for the Ceres Solver"
@@ -24,7 +24,7 @@ source = ["ceres-solver-sys/source"]
 default = ["system"]
 
 [dependencies.ceres-solver-sys]
-version = "0.2.1"
+version = "0.2.2"
 path = "./ceres-solver-sys"
 
 [dependencies.thiserror]

--- a/ceres-solver-sys/CHANGELOG.md
+++ b/ceres-solver-sys/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 --
 
+## [0.2.2] 2024-02-26
+
+### Changed
+
+- Require `ceres-solver` version to be between 2.0 and 2.1, 2.2 is known to be incompatible.
+
 ## [0.2.1] 2023-02-28
 
 ### Changed

--- a/ceres-solver-sys/Cargo.toml
+++ b/ceres-solver-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceres-solver-sys"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 readme = "README.md"
 description = "Unsafe Rust bindings for the Ceres Solver"

--- a/ceres-solver-sys/build.rs
+++ b/ceres-solver-sys/build.rs
@@ -25,7 +25,7 @@ fn main() {
             });
         }
         match pkg_config::Config::new()
-            .range_version("2.0.0".."3.0.0")
+            .range_version("2.0.0".."2.2.0")
             .probe("ceres")
         {
             Ok(library) => library.include_paths.into_iter().for_each(|path| {


### PR DESCRIPTION
Related but doesn't solve this issue:
https://github.com/light-curve/ceres-solver-rs/issues/21