### PR TITLE
MSRV 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ceres-solver"
 version = "0.5.0"
-edition = "2024"
+edition = "2021"
 readme = "README.md"
 description = "Safe Rust bindings for the Ceres Solver"
 repository = "https://github.com/light-curve/ceres-solver-rs"

--- a/ceres-solver-sys/Cargo.toml
+++ b/ceres-solver-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ceres-solver-sys"
 version = "0.5.0"
-edition = "2024"
+edition = "2021"
 readme = "README.md"
 description = "Unsafe Rust bindings for the Ceres Solver"
 repository = "https://github.com/light-curve/ceres-solver-rs"

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -3,7 +3,7 @@
 use crate::error::SolverOptionsBuildingError;
 use crate::residual_block::ResidualBlockId;
 
-use ceres_solver_sys::cxx::{UniquePtr, let_cxx_string};
+use ceres_solver_sys::cxx::{let_cxx_string, UniquePtr};
 use ceres_solver_sys::ffi;
 pub use ceres_solver_sys::ffi::{
     DenseLinearAlgebraLibraryType, DoglegType, DumpFormatType, LineSearchDirectionType,


### PR DESCRIPTION
Minimum Rust version bumps to 1.87, cxx dependency bumps, edition 2024 is used now. `ceres-solver-src` is still on older Rust version