### PR TITLE
Release Windows support: ceres-solver-src v0.5.1, ceres-solver-sys v0.5.3, ceres-solver v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `rand` from `0.9` to `0.10`, `rand_chacha` from `0.9` to `0.10`, and `rand_distr` from `0.5` to `0.6` in dev-dependencies.
+--
 
 ### Deprecated
 
@@ -30,6 +30,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 --
+
+## [0.5.1] 2026-04-06
+
+### Added
+
+- Windows support via `ceres-solver-sys` 0.5.3.
+
+### Changed
+
+- Bump `ceres-solver-sys` from `0.5.0` to `0.5.3`.
+- Bump `rand` from `0.9` to `0.10`, `rand_chacha` from `0.9` to `0.10`, and `rand_distr` from `0.5` to `0.6` in dev-dependencies.
 
 ## [0.5.0] 2025-12-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceres-solver"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 readme = "README.md"
 description = "Safe Rust bindings for the Ceres Solver"
@@ -22,7 +22,7 @@ source = ["ceres-solver-sys/source"]
 default = ["system"]
 
 [dependencies.ceres-solver-sys]
-version = "0.5.0"
+version = "0.5.3"
 path = "./ceres-solver-sys"
 
 [dependencies.thiserror]

--- a/ceres-solver-src/CHANGELOG.md
+++ b/ceres-solver-src/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Windows support: use Ninja generator with MSVC compilers (`cl.exe`) on Windows; disable Fortran detection via cmake sentinel value; disable Eigen BLAS/LAPACK optional components to prevent GFortran auto-detection; handle `lib/Release/` output path on Windows.
+--
 
 ### Changed
 
@@ -30,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 --
+
+## [0.5.1+ceres2.2.0-eigen3.4.0-glog0.7.1] 2026-04-06
+
+### Added
+
+- Windows support: use Ninja generator with MSVC compilers (`cl.exe`) on Windows; disable Fortran detection via cmake sentinel value; disable Eigen BLAS/LAPACK optional components to prevent GFortran auto-detection; handle `lib/Release/` output path on Windows.
 
 ## [0.5.0+ceres2.2.0-eigen3.4.0-glog0.7.1] 2025-12-13
 

--- a/ceres-solver-src/Cargo.toml
+++ b/ceres-solver-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceres-solver-src"
-version = "0.5.0+ceres2.2.0-eigen3.4.0-glog0.7.1"
+version = "0.5.1+ceres2.2.0-eigen3.4.0-glog0.7.1"
 edition = "2024"
 links = "ceres"
 readme = "README.md"

--- a/ceres-solver-sys/CHANGELOG.md
+++ b/ceres-solver-sys/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Windows support: vcpkg integration for system-installed Ceres on Windows (reads `VCPKG_ROOT` + `VCPKGRS_TRIPLET`); fallback to `CERES_INCLUDE_DIR`, `EIGEN3_INCLUDE_DIR`, `CERES_LIB_DIR` environment variables.
+--
 
 ### Changed
 
@@ -25,11 +25,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Windows build: link `shlwapi` (required by glog), define `GLOG_NO_ABBREVIATED_SEVERITIES` to avoid conflicts with `<windows.h>` macros, use `/std:c++17` for MSVC, and add `eigen3` sub-directory to include paths for vcpkg layout.
+--
 
 ### Security
 
 --
+
+## [0.5.3] 2026-04-06
+
+### Added
+
+- Windows support: vcpkg integration for system-installed Ceres on Windows (reads `VCPKG_ROOT` + `VCPKGRS_TRIPLET`); fallback to `CERES_INCLUDE_DIR`, `EIGEN3_INCLUDE_DIR`, `CERES_LIB_DIR` environment variables.
+
+### Changed
+
+- Bump `ceres-solver-src` from `0.5.0` to `0.5.1`.
+
+### Fixed
+
+- Windows build: link `shlwapi` (required by glog), define `GLOG_NO_ABBREVIATED_SEVERITIES` to avoid conflicts with `<windows.h>` macros, use `/std:c++17` for MSVC, and add `eigen3` sub-directory to include paths for vcpkg layout.
 
 ## [0.5.2] 2026-02-10
 

--- a/ceres-solver-sys/CHANGELOG.md
+++ b/ceres-solver-sys/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 --
 
+## [0.5.2] 2026-02-10
+
+### Fixed
+
+- Define `GLOG_USE_GLOG_EXPORT` unconditionally (not only for the `source` feature) to fix builds against newer system glog installations.
+
 ## [0.5.1] 2025-12-13
 
 ### Fixed

--- a/ceres-solver-sys/Cargo.toml
+++ b/ceres-solver-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceres-solver-sys"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 resolver = "3"
 readme = "README.md"
@@ -16,7 +16,7 @@ source = ["ceres-solver-src"]
 default = ["system"]
 
 [dependencies.ceres-solver-src]
-version = "0.5.0"
+version = "0.5.1"
 path = "../ceres-solver-src"
 optional = true
 


### PR DESCRIPTION
## Summary

- Add missing changelog entry for `ceres-solver-sys` v0.5.2 (glog fix released 2026-02-10)
- Release `ceres-solver-src` v0.5.1: Windows support via Ninja/MSVC CMake build
- Release `ceres-solver-sys` v0.5.3: Windows support via vcpkg integration and MSVC fixes
- Release `ceres-solver` v0.5.1: Windows support + rand dev-dep bumps

## Crates published

- https://crates.io/crates/ceres-solver-src/0.5.1
- https://crates.io/crates/ceres-solver-sys/0.5.3
- https://crates.io/crates/ceres-solver/0.5.1